### PR TITLE
Require npm 7 and node 14

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 @fortawesome:registry=https://npm.fontawesome.com/
 //npm.fontawesome.com/:_authToken=${NPM_TOKEN}
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "module": "dist/index.modern.js",
   "source": "src/index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=14.17.4",
+    "npm": ">=7"
   },
   "scripts": {
     "build": "microbundle-crl --no-compress --format modern,cjs",
@@ -35,7 +36,7 @@
     "react": "^17.0.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.14.6",
+    "@babel/core": "^7.15.0",
     "@storybook/addon-actions": "^6.1.1",
     "@storybook/addon-essentials": "^6.1.1",
     "@storybook/addon-links": "^6.1.1",


### PR DESCRIPTION
This enforces use of npm version 7 or more.
npm version 7 introduces lockfileVersion 2 for package-lock.json.
